### PR TITLE
Fixes startDate styles being overridden by endDate

### DIFF
--- a/src/components/Day/index.tsx
+++ b/src/components/Day/index.tsx
@@ -58,10 +58,10 @@ const NonTouchableDay = React.memo<NonTouchableDayProps>(
           isActive ? styles.activeDate : {},
           isActive ? theme.activeDayContainerStyle : {},
           isOutOfRange ? theme.dayOutOfRangeContainerStyle : {},
-          isStartDate ? styles.startDate : {},
-          isStartDate ? theme.startDateContainerStyle : {},
           isEndDate ? styles.endDate : {},
           isEndDate ? theme.endDateContainerStyle : {},
+          isStartDate ? styles.startDate : {},
+          isStartDate ? theme.startDateContainerStyle : {},
         ]}
       >
         <Text


### PR DESCRIPTION
## Before:

![before](https://user-images.githubusercontent.com/3504472/97369234-bd360980-1869-11eb-96d3-0a6c32c21e8e.gif)

## After:

![after](https://user-images.githubusercontent.com/3504472/97369238-c0c99080-1869-11eb-80a4-9b2fdc669b9e.gif)
