### PR TITLE
Add support for showSixWeeks

### DIFF
--- a/src/__tests__/Month.test.tsx
+++ b/src/__tests__/Month.test.tsx
@@ -52,4 +52,14 @@ describe('Month', () => {
     const tree = renderer.create(<Month {...props} />).toJSON();
     expect(tree).toMatchSnapshot();
   });
+
+  it('should show six weeks', () => {
+    const props: MonthProps = {
+      ...defaultProps,
+      showSixWeeks: true,
+    };
+
+    const tree = renderer.create(<Month {...props} />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/src/__tests__/__snapshots__/Month.test.tsx.snap
+++ b/src/__tests__/__snapshots__/Month.test.tsx.snap
@@ -9870,3 +9870,2468 @@ Array [
   </View>,
 ]
 `;
+
+exports[`Month should show six weeks 1`] = `
+Array [
+  <View
+    style={
+      Object {
+        "flexDirection": "row",
+      }
+    }
+  >
+    <View
+      style={
+        Array [
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "white",
+            "flex": 1,
+            "justifyContent": "center",
+            "marginVertical": 5,
+            "paddingVertical": 10,
+          },
+          undefined,
+          undefined,
+          Object {},
+          Object {},
+          Object {},
+          Object {},
+          Object {},
+          Object {},
+          Object {},
+          Object {},
+        ]
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "justifyContent": "center",
+            },
+            undefined,
+            Object {},
+          ]
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "#d3d3d3",
+              },
+              undefined,
+              Object {},
+              Object {},
+              Object {},
+            ]
+          }
+        >
+          24
+        </Text>
+      </View>
+    </View>
+    <View
+      style={
+        Array [
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "white",
+            "flex": 1,
+            "justifyContent": "center",
+            "marginVertical": 5,
+            "paddingVertical": 10,
+          },
+          undefined,
+          undefined,
+          Object {},
+          Object {},
+          Object {},
+          Object {},
+          Object {},
+          Object {},
+          Object {},
+          Object {},
+        ]
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "justifyContent": "center",
+            },
+            undefined,
+            Object {},
+          ]
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "#d3d3d3",
+              },
+              undefined,
+              Object {},
+              Object {},
+              Object {},
+            ]
+          }
+        >
+          25
+        </Text>
+      </View>
+    </View>
+    <View
+      style={
+        Array [
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "white",
+            "flex": 1,
+            "justifyContent": "center",
+            "marginVertical": 5,
+            "paddingVertical": 10,
+          },
+          undefined,
+          undefined,
+          Object {},
+          Object {},
+          Object {},
+          Object {},
+          Object {},
+          Object {},
+          Object {},
+          Object {},
+        ]
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "justifyContent": "center",
+            },
+            undefined,
+            Object {},
+          ]
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "#d3d3d3",
+              },
+              undefined,
+              Object {},
+              Object {},
+              Object {},
+            ]
+          }
+        >
+          26
+        </Text>
+      </View>
+    </View>
+    <View
+      style={
+        Array [
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "white",
+            "flex": 1,
+            "justifyContent": "center",
+            "marginVertical": 5,
+            "paddingVertical": 10,
+          },
+          undefined,
+          undefined,
+          Object {},
+          Object {},
+          Object {},
+          Object {},
+          Object {},
+          Object {},
+          Object {},
+          Object {},
+        ]
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "justifyContent": "center",
+            },
+            undefined,
+            Object {},
+          ]
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "#d3d3d3",
+              },
+              undefined,
+              Object {},
+              Object {},
+              Object {},
+            ]
+          }
+        >
+          27
+        </Text>
+      </View>
+    </View>
+    <View
+      style={
+        Array [
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "white",
+            "flex": 1,
+            "justifyContent": "center",
+            "marginVertical": 5,
+            "paddingVertical": 10,
+          },
+          undefined,
+          undefined,
+          Object {},
+          Object {},
+          Object {},
+          Object {},
+          Object {},
+          Object {},
+          Object {},
+          Object {},
+        ]
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "justifyContent": "center",
+            },
+            undefined,
+            Object {},
+          ]
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "#d3d3d3",
+              },
+              undefined,
+              Object {},
+              Object {},
+              Object {},
+            ]
+          }
+        >
+          28
+        </Text>
+      </View>
+    </View>
+    <View
+      style={
+        Array [
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "white",
+            "flex": 1,
+            "justifyContent": "center",
+            "marginVertical": 5,
+            "paddingVertical": 10,
+          },
+          undefined,
+          undefined,
+          Object {},
+          Object {},
+          Object {},
+          Object {},
+          Object {},
+          Object {},
+          Object {},
+          Object {},
+        ]
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "justifyContent": "center",
+            },
+            undefined,
+            Object {},
+          ]
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "#d3d3d3",
+              },
+              undefined,
+              Object {},
+              Object {},
+              Object {},
+            ]
+          }
+        >
+          29
+        </Text>
+      </View>
+    </View>
+    <View
+      accessible={true}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "white",
+          "flex": 1,
+          "justifyContent": "center",
+          "marginVertical": 5,
+          "opacity": 1,
+          "paddingVertical": 10,
+        }
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "justifyContent": "center",
+            },
+            undefined,
+            Object {},
+          ]
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "black",
+              },
+              undefined,
+              Object {},
+              Object {},
+            ]
+          }
+        >
+          1
+        </Text>
+        <View
+          style={
+            Object {
+              "bottom": 3,
+              "flexDirection": "row",
+              "position": "absolute",
+            }
+          }
+        />
+      </View>
+    </View>
+  </View>,
+  <View
+    style={
+      Object {
+        "flexDirection": "row",
+      }
+    }
+  >
+    <View
+      accessible={true}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "white",
+          "flex": 1,
+          "justifyContent": "center",
+          "marginVertical": 5,
+          "opacity": 1,
+          "paddingVertical": 10,
+        }
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "justifyContent": "center",
+            },
+            undefined,
+            Object {},
+          ]
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "black",
+              },
+              undefined,
+              Object {},
+              Object {},
+            ]
+          }
+        >
+          2
+        </Text>
+        <View
+          style={
+            Object {
+              "bottom": 3,
+              "flexDirection": "row",
+              "position": "absolute",
+            }
+          }
+        />
+      </View>
+    </View>
+    <View
+      accessible={true}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "white",
+          "flex": 1,
+          "justifyContent": "center",
+          "marginVertical": 5,
+          "opacity": 1,
+          "paddingVertical": 10,
+        }
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "justifyContent": "center",
+            },
+            undefined,
+            Object {},
+          ]
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "black",
+              },
+              undefined,
+              Object {},
+              Object {},
+            ]
+          }
+        >
+          3
+        </Text>
+        <View
+          style={
+            Object {
+              "bottom": 3,
+              "flexDirection": "row",
+              "position": "absolute",
+            }
+          }
+        />
+      </View>
+    </View>
+    <View
+      accessible={true}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "white",
+          "flex": 1,
+          "justifyContent": "center",
+          "marginVertical": 5,
+          "opacity": 1,
+          "paddingVertical": 10,
+        }
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "justifyContent": "center",
+            },
+            undefined,
+            Object {},
+          ]
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "black",
+              },
+              undefined,
+              Object {},
+              Object {},
+            ]
+          }
+        >
+          4
+        </Text>
+        <View
+          style={
+            Object {
+              "bottom": 3,
+              "flexDirection": "row",
+              "position": "absolute",
+            }
+          }
+        />
+      </View>
+    </View>
+    <View
+      accessible={true}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "white",
+          "flex": 1,
+          "justifyContent": "center",
+          "marginVertical": 5,
+          "opacity": 1,
+          "paddingVertical": 10,
+        }
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "justifyContent": "center",
+            },
+            undefined,
+            Object {},
+          ]
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "black",
+              },
+              undefined,
+              Object {},
+              Object {},
+            ]
+          }
+        >
+          5
+        </Text>
+        <View
+          style={
+            Object {
+              "bottom": 3,
+              "flexDirection": "row",
+              "position": "absolute",
+            }
+          }
+        />
+      </View>
+    </View>
+    <View
+      accessible={true}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "white",
+          "flex": 1,
+          "justifyContent": "center",
+          "marginVertical": 5,
+          "opacity": 1,
+          "paddingVertical": 10,
+        }
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "justifyContent": "center",
+            },
+            undefined,
+            Object {},
+          ]
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "black",
+              },
+              undefined,
+              Object {},
+              Object {},
+            ]
+          }
+        >
+          6
+        </Text>
+        <View
+          style={
+            Object {
+              "bottom": 3,
+              "flexDirection": "row",
+              "position": "absolute",
+            }
+          }
+        />
+      </View>
+    </View>
+    <View
+      accessible={true}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "white",
+          "flex": 1,
+          "justifyContent": "center",
+          "marginVertical": 5,
+          "opacity": 1,
+          "paddingVertical": 10,
+        }
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "justifyContent": "center",
+            },
+            undefined,
+            Object {},
+          ]
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "black",
+              },
+              undefined,
+              Object {},
+              Object {},
+            ]
+          }
+        >
+          7
+        </Text>
+        <View
+          style={
+            Object {
+              "bottom": 3,
+              "flexDirection": "row",
+              "position": "absolute",
+            }
+          }
+        />
+      </View>
+    </View>
+    <View
+      accessible={true}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "white",
+          "flex": 1,
+          "justifyContent": "center",
+          "marginVertical": 5,
+          "opacity": 1,
+          "paddingVertical": 10,
+        }
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "justifyContent": "center",
+            },
+            undefined,
+            Object {},
+          ]
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "black",
+              },
+              undefined,
+              Object {},
+              Object {},
+            ]
+          }
+        >
+          8
+        </Text>
+        <View
+          style={
+            Object {
+              "bottom": 3,
+              "flexDirection": "row",
+              "position": "absolute",
+            }
+          }
+        />
+      </View>
+    </View>
+  </View>,
+  <View
+    style={
+      Object {
+        "flexDirection": "row",
+      }
+    }
+  >
+    <View
+      accessible={true}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "white",
+          "flex": 1,
+          "justifyContent": "center",
+          "marginVertical": 5,
+          "opacity": 1,
+          "paddingVertical": 10,
+        }
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "justifyContent": "center",
+            },
+            undefined,
+            Object {},
+          ]
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "black",
+              },
+              undefined,
+              Object {},
+              Object {},
+            ]
+          }
+        >
+          9
+        </Text>
+        <View
+          style={
+            Object {
+              "bottom": 3,
+              "flexDirection": "row",
+              "position": "absolute",
+            }
+          }
+        />
+      </View>
+    </View>
+    <View
+      accessible={true}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "white",
+          "flex": 1,
+          "justifyContent": "center",
+          "marginVertical": 5,
+          "opacity": 1,
+          "paddingVertical": 10,
+        }
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "justifyContent": "center",
+            },
+            undefined,
+            Object {},
+          ]
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "black",
+              },
+              undefined,
+              Object {},
+              Object {},
+            ]
+          }
+        >
+          10
+        </Text>
+        <View
+          style={
+            Object {
+              "bottom": 3,
+              "flexDirection": "row",
+              "position": "absolute",
+            }
+          }
+        />
+      </View>
+    </View>
+    <View
+      accessible={true}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "white",
+          "flex": 1,
+          "justifyContent": "center",
+          "marginVertical": 5,
+          "opacity": 1,
+          "paddingVertical": 10,
+        }
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "justifyContent": "center",
+            },
+            undefined,
+            Object {},
+          ]
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "black",
+              },
+              undefined,
+              Object {},
+              Object {},
+            ]
+          }
+        >
+          11
+        </Text>
+        <View
+          style={
+            Object {
+              "bottom": 3,
+              "flexDirection": "row",
+              "position": "absolute",
+            }
+          }
+        />
+      </View>
+    </View>
+    <View
+      accessible={true}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "white",
+          "flex": 1,
+          "justifyContent": "center",
+          "marginVertical": 5,
+          "opacity": 1,
+          "paddingVertical": 10,
+        }
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "justifyContent": "center",
+            },
+            undefined,
+            Object {},
+          ]
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "black",
+              },
+              undefined,
+              Object {},
+              Object {},
+            ]
+          }
+        >
+          12
+        </Text>
+        <View
+          style={
+            Object {
+              "bottom": 3,
+              "flexDirection": "row",
+              "position": "absolute",
+            }
+          }
+        />
+      </View>
+    </View>
+    <View
+      accessible={true}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "white",
+          "flex": 1,
+          "justifyContent": "center",
+          "marginVertical": 5,
+          "opacity": 1,
+          "paddingVertical": 10,
+        }
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "justifyContent": "center",
+            },
+            undefined,
+            Object {},
+          ]
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "black",
+              },
+              undefined,
+              Object {},
+              Object {},
+            ]
+          }
+        >
+          13
+        </Text>
+        <View
+          style={
+            Object {
+              "bottom": 3,
+              "flexDirection": "row",
+              "position": "absolute",
+            }
+          }
+        />
+      </View>
+    </View>
+    <View
+      accessible={true}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "white",
+          "flex": 1,
+          "justifyContent": "center",
+          "marginVertical": 5,
+          "opacity": 1,
+          "paddingVertical": 10,
+        }
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "justifyContent": "center",
+            },
+            undefined,
+            Object {},
+          ]
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "black",
+              },
+              undefined,
+              Object {},
+              Object {},
+            ]
+          }
+        >
+          14
+        </Text>
+        <View
+          style={
+            Object {
+              "bottom": 3,
+              "flexDirection": "row",
+              "position": "absolute",
+            }
+          }
+        />
+      </View>
+    </View>
+    <View
+      accessible={true}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "white",
+          "flex": 1,
+          "justifyContent": "center",
+          "marginVertical": 5,
+          "opacity": 1,
+          "paddingVertical": 10,
+        }
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "justifyContent": "center",
+            },
+            undefined,
+            Object {},
+          ]
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "black",
+              },
+              undefined,
+              Object {},
+              Object {},
+            ]
+          }
+        >
+          15
+        </Text>
+        <View
+          style={
+            Object {
+              "bottom": 3,
+              "flexDirection": "row",
+              "position": "absolute",
+            }
+          }
+        />
+      </View>
+    </View>
+  </View>,
+  <View
+    style={
+      Object {
+        "flexDirection": "row",
+      }
+    }
+  >
+    <View
+      accessible={true}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "white",
+          "flex": 1,
+          "justifyContent": "center",
+          "marginVertical": 5,
+          "opacity": 1,
+          "paddingVertical": 10,
+        }
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "justifyContent": "center",
+            },
+            undefined,
+            Object {},
+          ]
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "black",
+              },
+              undefined,
+              Object {},
+              Object {},
+            ]
+          }
+        >
+          16
+        </Text>
+        <View
+          style={
+            Object {
+              "bottom": 3,
+              "flexDirection": "row",
+              "position": "absolute",
+            }
+          }
+        />
+      </View>
+    </View>
+    <View
+      accessible={true}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "white",
+          "flex": 1,
+          "justifyContent": "center",
+          "marginVertical": 5,
+          "opacity": 1,
+          "paddingVertical": 10,
+        }
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "justifyContent": "center",
+            },
+            undefined,
+            Object {},
+          ]
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "black",
+              },
+              undefined,
+              Object {},
+              Object {},
+            ]
+          }
+        >
+          17
+        </Text>
+        <View
+          style={
+            Object {
+              "bottom": 3,
+              "flexDirection": "row",
+              "position": "absolute",
+            }
+          }
+        />
+      </View>
+    </View>
+    <View
+      accessible={true}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "white",
+          "flex": 1,
+          "justifyContent": "center",
+          "marginVertical": 5,
+          "opacity": 1,
+          "paddingVertical": 10,
+        }
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "justifyContent": "center",
+            },
+            undefined,
+            Object {},
+          ]
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "black",
+              },
+              undefined,
+              Object {},
+              Object {},
+            ]
+          }
+        >
+          18
+        </Text>
+        <View
+          style={
+            Object {
+              "bottom": 3,
+              "flexDirection": "row",
+              "position": "absolute",
+            }
+          }
+        />
+      </View>
+    </View>
+    <View
+      accessible={true}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "white",
+          "flex": 1,
+          "justifyContent": "center",
+          "marginVertical": 5,
+          "opacity": 1,
+          "paddingVertical": 10,
+        }
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "justifyContent": "center",
+            },
+            undefined,
+            Object {},
+          ]
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "black",
+              },
+              undefined,
+              Object {},
+              Object {},
+            ]
+          }
+        >
+          19
+        </Text>
+        <View
+          style={
+            Object {
+              "bottom": 3,
+              "flexDirection": "row",
+              "position": "absolute",
+            }
+          }
+        />
+      </View>
+    </View>
+    <View
+      accessible={true}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "white",
+          "flex": 1,
+          "justifyContent": "center",
+          "marginVertical": 5,
+          "opacity": 1,
+          "paddingVertical": 10,
+        }
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "justifyContent": "center",
+            },
+            undefined,
+            Object {},
+          ]
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "black",
+              },
+              undefined,
+              Object {},
+              Object {},
+            ]
+          }
+        >
+          20
+        </Text>
+        <View
+          style={
+            Object {
+              "bottom": 3,
+              "flexDirection": "row",
+              "position": "absolute",
+            }
+          }
+        />
+      </View>
+    </View>
+    <View
+      accessible={true}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "white",
+          "flex": 1,
+          "justifyContent": "center",
+          "marginVertical": 5,
+          "opacity": 1,
+          "paddingVertical": 10,
+        }
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "justifyContent": "center",
+            },
+            undefined,
+            Object {},
+          ]
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "black",
+              },
+              undefined,
+              Object {},
+              Object {},
+            ]
+          }
+        >
+          21
+        </Text>
+        <View
+          style={
+            Object {
+              "bottom": 3,
+              "flexDirection": "row",
+              "position": "absolute",
+            }
+          }
+        />
+      </View>
+    </View>
+    <View
+      accessible={true}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "white",
+          "flex": 1,
+          "justifyContent": "center",
+          "marginVertical": 5,
+          "opacity": 1,
+          "paddingVertical": 10,
+        }
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "justifyContent": "center",
+            },
+            undefined,
+            Object {},
+          ]
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "black",
+              },
+              undefined,
+              Object {},
+              Object {},
+            ]
+          }
+        >
+          22
+        </Text>
+        <View
+          style={
+            Object {
+              "bottom": 3,
+              "flexDirection": "row",
+              "position": "absolute",
+            }
+          }
+        />
+      </View>
+    </View>
+  </View>,
+  <View
+    style={
+      Object {
+        "flexDirection": "row",
+      }
+    }
+  >
+    <View
+      accessible={true}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "white",
+          "flex": 1,
+          "justifyContent": "center",
+          "marginVertical": 5,
+          "opacity": 1,
+          "paddingVertical": 10,
+        }
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "justifyContent": "center",
+            },
+            undefined,
+            Object {},
+          ]
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "black",
+              },
+              undefined,
+              Object {},
+              Object {},
+            ]
+          }
+        >
+          23
+        </Text>
+        <View
+          style={
+            Object {
+              "bottom": 3,
+              "flexDirection": "row",
+              "position": "absolute",
+            }
+          }
+        />
+      </View>
+    </View>
+    <View
+      accessible={true}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "white",
+          "flex": 1,
+          "justifyContent": "center",
+          "marginVertical": 5,
+          "opacity": 1,
+          "paddingVertical": 10,
+        }
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "justifyContent": "center",
+            },
+            undefined,
+            Object {},
+          ]
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "black",
+              },
+              undefined,
+              Object {},
+              Object {},
+            ]
+          }
+        >
+          24
+        </Text>
+        <View
+          style={
+            Object {
+              "bottom": 3,
+              "flexDirection": "row",
+              "position": "absolute",
+            }
+          }
+        />
+      </View>
+    </View>
+    <View
+      accessible={true}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "white",
+          "flex": 1,
+          "justifyContent": "center",
+          "marginVertical": 5,
+          "opacity": 1,
+          "paddingVertical": 10,
+        }
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "justifyContent": "center",
+            },
+            undefined,
+            Object {},
+          ]
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "black",
+              },
+              undefined,
+              Object {},
+              Object {},
+            ]
+          }
+        >
+          25
+        </Text>
+        <View
+          style={
+            Object {
+              "bottom": 3,
+              "flexDirection": "row",
+              "position": "absolute",
+            }
+          }
+        />
+      </View>
+    </View>
+    <View
+      accessible={true}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "white",
+          "flex": 1,
+          "justifyContent": "center",
+          "marginVertical": 5,
+          "opacity": 1,
+          "paddingVertical": 10,
+        }
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "justifyContent": "center",
+            },
+            undefined,
+            Object {},
+          ]
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "black",
+              },
+              undefined,
+              Object {},
+              Object {},
+            ]
+          }
+        >
+          26
+        </Text>
+        <View
+          style={
+            Object {
+              "bottom": 3,
+              "flexDirection": "row",
+              "position": "absolute",
+            }
+          }
+        />
+      </View>
+    </View>
+    <View
+      accessible={true}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "white",
+          "flex": 1,
+          "justifyContent": "center",
+          "marginVertical": 5,
+          "opacity": 1,
+          "paddingVertical": 10,
+        }
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "justifyContent": "center",
+            },
+            undefined,
+            Object {},
+          ]
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "black",
+              },
+              undefined,
+              Object {},
+              Object {},
+            ]
+          }
+        >
+          27
+        </Text>
+        <View
+          style={
+            Object {
+              "bottom": 3,
+              "flexDirection": "row",
+              "position": "absolute",
+            }
+          }
+        />
+      </View>
+    </View>
+    <View
+      accessible={true}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "white",
+          "flex": 1,
+          "justifyContent": "center",
+          "marginVertical": 5,
+          "opacity": 1,
+          "paddingVertical": 10,
+        }
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "justifyContent": "center",
+            },
+            undefined,
+            Object {},
+          ]
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "black",
+              },
+              undefined,
+              Object {},
+              Object {},
+            ]
+          }
+        >
+          28
+        </Text>
+        <View
+          style={
+            Object {
+              "bottom": 3,
+              "flexDirection": "row",
+              "position": "absolute",
+            }
+          }
+        />
+      </View>
+    </View>
+    <View
+      accessible={true}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "white",
+          "flex": 1,
+          "justifyContent": "center",
+          "marginVertical": 5,
+          "opacity": 1,
+          "paddingVertical": 10,
+        }
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "justifyContent": "center",
+            },
+            undefined,
+            Object {},
+          ]
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "black",
+              },
+              undefined,
+              Object {},
+              Object {},
+            ]
+          }
+        >
+          29
+        </Text>
+        <View
+          style={
+            Object {
+              "bottom": 3,
+              "flexDirection": "row",
+              "position": "absolute",
+            }
+          }
+        />
+      </View>
+    </View>
+  </View>,
+  <View
+    style={
+      Object {
+        "flexDirection": "row",
+      }
+    }
+  >
+    <View
+      accessible={true}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "white",
+          "flex": 1,
+          "justifyContent": "center",
+          "marginVertical": 5,
+          "opacity": 1,
+          "paddingVertical": 10,
+        }
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "justifyContent": "center",
+            },
+            undefined,
+            Object {},
+          ]
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "black",
+              },
+              undefined,
+              Object {},
+              Object {},
+            ]
+          }
+        >
+          30
+        </Text>
+        <View
+          style={
+            Object {
+              "bottom": 3,
+              "flexDirection": "row",
+              "position": "absolute",
+            }
+          }
+        />
+      </View>
+    </View>
+    <View
+      accessible={true}
+      focusable={true}
+      onClick={[Function]}
+      onResponderGrant={[Function]}
+      onResponderMove={[Function]}
+      onResponderRelease={[Function]}
+      onResponderTerminate={[Function]}
+      onResponderTerminationRequest={[Function]}
+      onStartShouldSetResponder={[Function]}
+      style={
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "white",
+          "flex": 1,
+          "justifyContent": "center",
+          "marginVertical": 5,
+          "opacity": 1,
+          "paddingVertical": 10,
+        }
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "justifyContent": "center",
+            },
+            undefined,
+            Object {},
+          ]
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "black",
+              },
+              undefined,
+              Object {},
+              Object {},
+            ]
+          }
+        >
+          31
+        </Text>
+        <View
+          style={
+            Object {
+              "bottom": 3,
+              "flexDirection": "row",
+              "position": "absolute",
+            }
+          }
+        />
+      </View>
+    </View>
+    <View
+      style={
+        Array [
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "white",
+            "flex": 1,
+            "justifyContent": "center",
+            "marginVertical": 5,
+            "paddingVertical": 10,
+          },
+          undefined,
+          undefined,
+          Object {},
+          Object {},
+          Object {},
+          Object {},
+          Object {},
+          Object {},
+          Object {},
+          Object {},
+        ]
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "justifyContent": "center",
+            },
+            undefined,
+            Object {},
+          ]
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "#d3d3d3",
+              },
+              undefined,
+              Object {},
+              Object {},
+              Object {},
+            ]
+          }
+        >
+          1
+        </Text>
+      </View>
+    </View>
+    <View
+      style={
+        Array [
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "white",
+            "flex": 1,
+            "justifyContent": "center",
+            "marginVertical": 5,
+            "paddingVertical": 10,
+          },
+          undefined,
+          undefined,
+          Object {},
+          Object {},
+          Object {},
+          Object {},
+          Object {},
+          Object {},
+          Object {},
+          Object {},
+        ]
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "justifyContent": "center",
+            },
+            undefined,
+            Object {},
+          ]
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "#d3d3d3",
+              },
+              undefined,
+              Object {},
+              Object {},
+              Object {},
+            ]
+          }
+        >
+          2
+        </Text>
+      </View>
+    </View>
+    <View
+      style={
+        Array [
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "white",
+            "flex": 1,
+            "justifyContent": "center",
+            "marginVertical": 5,
+            "paddingVertical": 10,
+          },
+          undefined,
+          undefined,
+          Object {},
+          Object {},
+          Object {},
+          Object {},
+          Object {},
+          Object {},
+          Object {},
+          Object {},
+        ]
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "justifyContent": "center",
+            },
+            undefined,
+            Object {},
+          ]
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "#d3d3d3",
+              },
+              undefined,
+              Object {},
+              Object {},
+              Object {},
+            ]
+          }
+        >
+          3
+        </Text>
+      </View>
+    </View>
+    <View
+      style={
+        Array [
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "white",
+            "flex": 1,
+            "justifyContent": "center",
+            "marginVertical": 5,
+            "paddingVertical": 10,
+          },
+          undefined,
+          undefined,
+          Object {},
+          Object {},
+          Object {},
+          Object {},
+          Object {},
+          Object {},
+          Object {},
+          Object {},
+        ]
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "justifyContent": "center",
+            },
+            undefined,
+            Object {},
+          ]
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "#d3d3d3",
+              },
+              undefined,
+              Object {},
+              Object {},
+              Object {},
+            ]
+          }
+        >
+          4
+        </Text>
+      </View>
+    </View>
+    <View
+      style={
+        Array [
+          Object {
+            "alignItems": "center",
+            "backgroundColor": "white",
+            "flex": 1,
+            "justifyContent": "center",
+            "marginVertical": 5,
+            "paddingVertical": 10,
+          },
+          undefined,
+          undefined,
+          Object {},
+          Object {},
+          Object {},
+          Object {},
+          Object {},
+          Object {},
+          Object {},
+          Object {},
+        ]
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "justifyContent": "center",
+            },
+            undefined,
+            Object {},
+          ]
+        }
+      >
+        <Text
+          style={
+            Array [
+              Object {
+                "color": "#d3d3d3",
+              },
+              undefined,
+              Object {},
+              Object {},
+              Object {},
+            ]
+          }
+        >
+          5
+        </Text>
+      </View>
+    </View>
+  </View>,
+]
+`;

--- a/src/components/Month/index.tsx
+++ b/src/components/Month/index.tsx
@@ -31,6 +31,7 @@ export default React.memo<MonthProps>((props: MonthProps) => {
     markedDays = {},
     theme = {},
     renderDayContent,
+    showSixWeeks = false,
   } = props;
 
   const DAY_NAMES =
@@ -48,7 +49,8 @@ export default React.memo<MonthProps>((props: MonthProps) => {
     startDate,
     endDate,
     minDate,
-    maxDate
+    maxDate,
+    showSixWeeks
   );
 
   const weeks = [];

--- a/src/components/utils.tsx
+++ b/src/components/utils.tsx
@@ -28,7 +28,8 @@ export function getMonthDays(
   startDate?: Date,
   endDate?: Date,
   minDate?: Date,
-  maxDate?: Date
+  maxDate?: Date,
+  showSixWeeks?: boolean
 ): DayType[] {
   if (minDate instanceof Date) minDate.setHours(0, 0, 0, 0);
   if (maxDate instanceof Date) maxDate.setHours(0, 0, 0, 0);
@@ -45,7 +46,13 @@ export function getMonthDays(
     ? MONDAY_FIRST[firstMonthDay.getDay()]
     : firstMonthDay.getDay();
   const daysToCompleteRows = (startWeekOffset + daysToAdd) % 7;
-  const lastRowNextMonthDays = daysToCompleteRows ? 7 - daysToCompleteRows : 0;
+  let lastRowNextMonthDays = daysToCompleteRows ? 7 - daysToCompleteRows : 0;
+  const totalDays = startWeekOffset + daysToAdd + lastRowNextMonthDays;
+  const sixWeekDays = 42;
+
+  if (showSixWeeks && totalDays !== sixWeekDays) {
+    lastRowNextMonthDays += sixWeekDays - totalDays;
+  }
 
   for (let i = -startWeekOffset; i < daysToAdd + lastRowNextMonthDays; i++) {
     const date: Date = addDays(firstMonthDay, i);

--- a/src/types.ts
+++ b/src/types.ts
@@ -136,6 +136,7 @@ export interface MonthProps {
   minDate?: Date;
   maxDate?: Date;
   markedDays?: MarkedDays;
+  showSixWeeks?: boolean;
   theme?: ThemeType;
   renderDayContent?: (day: DayType) => ReactElement;
   disabledDays?: { [key: string]: any };


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation

<!-- What existing problem does the pull request solve? Can you solve the issue with a different approach? -->

I'm working on a project using `react-native-month`, and I came across the problem that the size of the container changes when months with a different number of weeks are in a row.

This would close #65.

### Test plan

<!-- List the steps with which we can test this change. Provide screenshots if this changes anything visual. -->

If you set the `showSixWeeks` prop to `true` then the month will always have six weeks (42 days). I included a new test and modified the snapshot file.

<img width="320" alt="Screen Shot 2022-05-27 at 5 05 54 PM" src="https://user-images.githubusercontent.com/59693490/170789424-49b6922b-1494-45a3-91c6-107ce7f7278f.png">

If you look at the above image, the last line does not have any days of the current month.

