### PR TITLE
fix: missing endDateContainerStyle

### DIFF
--- a/src/components/Day/index.tsx
+++ b/src/components/Day/index.tsx
@@ -219,6 +219,7 @@ const Day = React.memo<Props>(
           isStartDate ? theme.startDateContainerStyle : {},
           isStartDate ? dayTheme?.startDateContainerStyle : {},
           isEndDate ? styles.endDate : {},
+          isEndDate ? theme.endDateContainerStyle : {},
           isEndDate ? dayTheme?.endDateContainerStyle : {},
         ]}
         onPress={() => props.onPress(props.item.date)}


### PR DESCRIPTION
### Motivation

Add missing `endDateContainerStyle` usage

### Test plan

n/a